### PR TITLE
Add Header size function for IPv6 and IPv4

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -936,7 +936,7 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
 
     if( pxNetworkBuffer != NULL )
     {
-        pxNetworkBuffer->ulIPAddress = ulIPAddress;
+        pxNetworkBuffer->xIPAddress.xIP_IPv4 = ulIPAddress;
         vARPGenerateRequestPacket( pxNetworkBuffer );
 
         #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
@@ -1115,11 +1115,11 @@ void vARPGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffe
     pvCopySource = ipLOCAL_IP_ADDRESS_POINTER;
     pvCopyDest = pxARPPacket->xARPHeader.ucSenderProtocolAddress;
     ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxARPPacket->xARPHeader.ucSenderProtocolAddress ) );
-    pxARPPacket->xARPHeader.ulTargetProtocolAddress = pxNetworkBuffer->ulIPAddress;
+    pxARPPacket->xARPHeader.ulTargetProtocolAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
 
     pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
-    iptraceCREATING_ARP_REQUEST( pxNetworkBuffer->ulIPAddress );
+    iptraceCREATING_ARP_REQUEST( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
 }
 /*-----------------------------------------------------------*/
 

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -740,6 +740,7 @@
             IPHeader_t * pxIPHeader;
             UDPHeader_t * pxUDPHeader;
             size_t uxDataLength;
+            const size_t uxIPHeaderLength = uxIPHeaderSizePacket( pxNetworkBuffer );
 
             pxUDPPacket = ( ( UDPPacket_t * )
                             pxNetworkBuffer->pucEthernetBuffer );
@@ -747,7 +748,7 @@
             pxUDPHeader = &pxUDPPacket->xUDPHeader;
             /* HT: started using defines like 'ipSIZE_OF_xxx' */
             pxIPHeader->usLength = FreeRTOS_htons( ( uint16_t ) lNetLength +
-                                                   ipSIZE_OF_IPv4_HEADER +
+                                                   uxIPHeaderLength +
                                                    ipSIZE_OF_UDP_HEADER );
             /* HT:endian: should not be translated, copying from packet to packet */
             pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
@@ -769,13 +770,13 @@
             vFlip_16( pxUDPHeader->usSourcePort, pxUDPHeader->usDestinationPort );
 
             /* Important: tell NIC driver how many bytes must be sent */
-            uxDataLength = ( ( size_t ) lNetLength ) + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER;
+            uxDataLength = ( ( size_t ) lNetLength ) + uxIPHeaderLength + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER;
 
             #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
                 {
                     /* Calculate the IP header checksum. */
                     pxIPHeader->usHeaderChecksum = 0U;
-                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), uxIPHeaderLength );
                     pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
                     /* calculate the UDP checksum for outgoing package */

--- a/source/FreeRTOS_ICMP.c
+++ b/source/FreeRTOS_ICMP.c
@@ -169,7 +169,7 @@
             {
                 /* calculate the IP header checksum, in case the driver won't do that. */
                 pxIPHeader->usHeaderChecksum = 0x00U;
-                pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+                pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), uxIPHeaderSizePacket( pxNetworkBuffer ) );
                 pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
                 /* calculate the ICMP checksum for an outgoing packet. */

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -2165,6 +2165,53 @@ BaseType_t FreeRTOS_IsNetworkUp( void )
 #endif
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Get the size of the IP-header, by checking the type of the network buffer.
+ * @param[in] pxNetworkBuffer: The network buffer.
+ * @return The size of the corresponding IP-header.
+ */
+size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
+{
+    size_t uxResult;
+    /* Map the buffer onto Ethernet Header struct for easy access to fields. */
+    /* misra_c_2012_rule_11_3_violation */
+    const EthernetHeader_t * pxHeader = ( ( const EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    if( pxHeader->usFrameType == ( uint16_t ) ipIPv6_FRAME_TYPE )
+    {
+        uxResult = ipSIZE_OF_IPv6_HEADER;
+    }
+    else
+    {
+        uxResult = ipSIZE_OF_IPv4_HEADER;
+    }
+
+    return uxResult;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the size of the IP-header, by checking if the socket bIsIPv6 set.
+ * @param[in] pxSocket: The socket.
+ * @return The size of the corresponding IP-header.
+ */
+size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
+{
+    size_t uxResult;
+
+    if( ( pxSocket != NULL ) && ( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED ) )
+    {
+        uxResult = ipSIZE_OF_IPv6_HEADER;
+    }
+    else
+    {
+        uxResult = ipSIZE_OF_IPv4_HEADER;
+    }
+
+    return uxResult;
+}
+/*-----------------------------------------------------------*/
+
 /* Provide access to private members for verification. */
 #ifdef FREERTOS_TCP_ENABLE_VERIFICATION
     #include "aws_freertos_ip_verification_access_ip_define.h"

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1040,7 +1040,7 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
                 /* The message is complete, IP and checksum's are handled by
                  * vProcessGeneratedUDPPacket */
                 pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = FREERTOS_SO_UDPCKSUM_OUT;
-                pxNetworkBuffer->ulIPAddress = ulIPAddress;
+                pxNetworkBuffer->xIPAddress.xIP_IPv4 = ulIPAddress;
                 pxNetworkBuffer->usPort = ipPACKET_CONTAINS_ICMP_DATA;
                 /* xDataLength is the size of the total packet, including the Ethernet header. */
                 pxNetworkBuffer->xDataLength = uxTotalLength;
@@ -1757,7 +1757,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
 
                                    /* Fields in pxNetworkBuffer (usPort, ulIPAddress) are network order. */
                                    pxNetworkBuffer->usPort = pxUDPPacket->xUDPHeader.usSourcePort;
-                                   pxNetworkBuffer->ulIPAddress = pxUDPPacket->xIPHeader.ulSourceIPAddress;
+                                   pxNetworkBuffer->xIPAddress.xIP_IPv4 = pxUDPPacket->xIPHeader.ulSourceIPAddress;
 
                                    /* ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM:
                                     * In some cases, the upper-layer checksum has been calculated

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -199,7 +199,7 @@ NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const Networ
         pxNewBuffer->xDataLength = uxNewLength;
 
         /* Copy the original packet information. */
-        pxNewBuffer->ulIPAddress = pxNetworkBuffer->ulIPAddress;
+        pxNewBuffer->xIPAddress.xIP_IPv4 = pxNetworkBuffer->xIPAddress.xIP_IPv4;
         pxNewBuffer->usPort = pxNetworkBuffer->usPort;
         pxNewBuffer->usBoundPort = pxNetworkBuffer->usBoundPort;
         ( void ) memcpy( pxNewBuffer->pucEthernetBuffer, pxNetworkBuffer->pucEthernetBuffer, uxLengthToCopy );

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -4829,9 +4829,9 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
                 }
 
                 FreeRTOS_printf( ( "TCP %5u %-16xip:%5u %d/%d %-13.13s %6u %6u%s\n",
-                                   pxSocket->usLocalPort,                    /* Local port on this machine */
+                                   pxSocket->usLocalPort,                            /* Local port on this machine */
                                    ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, /* IP address of remote machine */
-                                   pxSocket->u.xTCP.usRemotePort,            /* Port on remote machine */
+                                   pxSocket->u.xTCP.usRemotePort,                    /* Port on remote machine */
                                    ( pxSocket->u.xTCP.rxStream != NULL ) ? 1 : 0,
                                    ( pxSocket->u.xTCP.txStream != NULL ) ? 1 : 0,
                                    FreeRTOS_GetTCPStateName( pxSocket->u.xTCP.eTCPState ),

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -969,7 +969,7 @@ int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
             if( pxSourceAddress != NULL )
             {
                 pxSourceAddress->sin_port = pxNetworkBuffer->usPort;
-                pxSourceAddress->sin_addr = pxNetworkBuffer->ulIPAddress;
+                pxSourceAddress->sin_addr = pxNetworkBuffer->xIPAddress.xIP_IPv4;
             }
 
             if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_ZERO_COPY ) == 0U )
@@ -1150,7 +1150,7 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
                 pxNetworkBuffer->xDataLength = uxTotalDataLength + sizeof( UDPPacket_t );
                 pxNetworkBuffer->usPort = pxDestinationAddress->sin_port;
                 pxNetworkBuffer->usBoundPort = ( uint16_t ) socketGET_SOCKET_PORT( pxSocket );
-                pxNetworkBuffer->ulIPAddress = pxDestinationAddress->sin_addr;
+                pxNetworkBuffer->xIPAddress.xIP_IPv4 = pxDestinationAddress->sin_addr;
 
                 /* The socket options are passed to the IP layer in the
                  * space that will eventually get used by the Ethernet header. */
@@ -1622,7 +1622,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
             {
                 FreeRTOS_debug_printf( ( "FreeRTOS_closesocket[%u to %xip:%u]: buffers %u socks %u\n",
                                          pxSocket->usLocalPort,
-                                         ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
+                                         ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
                                          pxSocket->u.xTCP.usRemotePort,
                                          ( unsigned ) uxGetNumberOfFreeNetworkBuffers(),
                                          ( unsigned ) listCURRENT_LIST_LENGTH( &xBoundTCPSocketsList ) ) );
@@ -3047,7 +3047,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 pxSocket->u.xTCP.usRemotePort = FreeRTOS_ntohs( pxAddress->sin_port );
 
                 /* IP address of remote machine. */
-                pxSocket->u.xTCP.ulRemoteIP = FreeRTOS_ntohl( pxAddress->sin_addr );
+                pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 = FreeRTOS_ntohl( pxAddress->sin_addr );
 
                 /* (client) internal state: socket wants to send a connect. */
                 vTCPStateChange( pxSocket, eCONNECT_SYN );
@@ -3232,7 +3232,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     if( pxAddress != NULL )
                     {
                         /* IP address of remote machine. */
-                        pxAddress->sin_addr = FreeRTOS_ntohl( pxClientSocket->u.xTCP.ulRemoteIP );
+                        pxAddress->sin_addr = FreeRTOS_ntohl( pxClientSocket->u.xTCP.xRemoteIP.xIP_IPv4 );
 
                         /* Port on remote machine. */
                         pxAddress->sin_port = FreeRTOS_ntohs( pxClientSocket->u.xTCP.usRemotePort );
@@ -3812,7 +3812,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     {
                         FreeRTOS_debug_printf( ( "FreeRTOS_send: %u -> %xip:%d: no space\n",
                                                  pxSocket->usLocalPort,
-                                                 ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
+                                                 ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
                                                  pxSocket->u.xTCP.usRemotePort ) );
                     }
 
@@ -4094,7 +4094,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                      * in case there is no perfect match. */
                     pxListenSocket = pxSocket;
                 }
-                else if( ( pxSocket->u.xTCP.usRemotePort == ( uint16_t ) uxRemotePort ) && ( pxSocket->u.xTCP.ulRemoteIP == ulRemoteIP ) )
+                else if( ( pxSocket->u.xTCP.usRemotePort == ( uint16_t ) uxRemotePort ) && ( pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 == ulRemoteIP ) )
                 {
                     /* For sockets not in listening mode, find a match with
                      * xLocalPort, ulRemoteIP AND xRemotePort. */
@@ -4432,7 +4432,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             /* BSD style sockets communicate IP and port addresses in network
              * byte order.
              * IP address of remote machine. */
-            pxAddress->sin_addr = FreeRTOS_htonl( pxSocket->u.xTCP.ulRemoteIP );
+            pxAddress->sin_addr = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 );
 
             /* Port on remote machine. */
             pxAddress->sin_port = FreeRTOS_htons( pxSocket->u.xTCP.usRemotePort );
@@ -4830,7 +4830,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 
                 FreeRTOS_printf( ( "TCP %5u %-16xip:%5u %d/%d %-13.13s %6u %6u%s\n",
                                    pxSocket->usLocalPort,                    /* Local port on this machine */
-                                   ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, /* IP address of remote machine */
+                                   ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, /* IP address of remote machine */
                                    pxSocket->u.xTCP.usRemotePort,            /* Port on remote machine */
                                    ( pxSocket->u.xTCP.rxStream != NULL ) ? 1 : 0,
                                    ( pxSocket->u.xTCP.txStream != NULL ) ? 1 : 0,

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -169,10 +169,10 @@
                                                          pxSocket->u.xTCP.usRemotePort,
                                                          ( unsigned ) ( pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber ),
                                                          ( unsigned ) ( pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber - pxSocket->u.xTCP.xTCPWindow.tx.ulFirstSequenceNumber ),
-                                                         ( unsigned ) ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) ) );
+                                                         ( unsigned ) ( uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER ) ) );
                             }
 
-                            prvTCPReturnPacket( pxSocket, pxSocket->u.xTCP.pxAckMessage, ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER, ipconfigZERO_COPY_TX_DRIVER );
+                            prvTCPReturnPacket( pxSocket, pxSocket->u.xTCP.pxAckMessage, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER, ipconfigZERO_COPY_TX_DRIVER );
 
                             #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
                                 {

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -426,7 +426,7 @@
                 {
                     FreeRTOS_debug_printf( ( "Socket %u -> %xip:%u State %s->%s\n",
                                              pxSocket->usLocalPort,
-                                             ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
+                                             ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
                                              pxSocket->u.xTCP.usRemotePort,
                                              FreeRTOS_GetTCPStateName( ( UBaseType_t ) xPreviousState ),
                                              FreeRTOS_GetTCPStateName( ( UBaseType_t ) eTCPState ) ) );
@@ -486,7 +486,7 @@
             }
 
             FreeRTOS_debug_printf( ( "Connect[%xip:%u]: next timeout %u: %u ms\n",
-                                     ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, pxSocket->u.xTCP.usRemotePort,
+                                     ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, pxSocket->u.xTCP.usRemotePort,
                                      pxSocket->u.xTCP.ucRepCount, ( unsigned ) ulDelayMs ) );
             pxSocket->u.xTCP.usTimeout = ( uint16_t ) ipMS_TO_MIN_TICKS( ulDelayMs );
         }

--- a/source/FreeRTOS_TCP_Reception.c
+++ b/source/FreeRTOS_TCP_Reception.c
@@ -443,7 +443,7 @@
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
         const IPHeader_t * pxIPHeader = ( ( const IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-        const size_t xIPHeaderLength = ipSIZE_OF_IPv4_HEADER;
+        const size_t xIPHeaderLength = uxIPHeaderSizePacket( pxNetworkBuffer );
         uint16_t usLength;
         uint8_t ucIntermediateResult = 0;
 

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -314,7 +314,7 @@
 
         if( pxTCPHeader->ucTCPFlags != 0U )
         {
-            ucIntermediateResult = uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + pxTCPWindow->ucOptionLength;
+            ucIntermediateResult = ( uint8_t ) ( uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + pxTCPWindow->ucOptionLength );
             xSendLength = ( BaseType_t ) ucIntermediateResult;
         }
 

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -195,7 +195,7 @@
                         {
                             FreeRTOS_debug_printf( ( "Inactive socket closed: port %u rem %xip:%u status %s\n",
                                                      pxSocket->usLocalPort,
-                                                     ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
+                                                     ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
                                                      pxSocket->u.xTCP.usRemotePort,
                                                      FreeRTOS_GetTCPStateName( ( UBaseType_t ) pxSocket->u.xTCP.eTCPState ) ) );
                         }
@@ -446,7 +446,7 @@
                     FreeRTOS_debug_printf( ( "TCP: %s %u => %xip:%u set ESTAB (scaling %u)\n",
                                              ( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eCONNECT_SYN ) ? "active" : "passive",
                                              pxSocket->usLocalPort,
-                                             ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
+                                             ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
                                              pxSocket->u.xTCP.usRemotePort,
                                              ( unsigned ) pxSocket->u.xTCP.bits.bWinScaling ) );
                 }
@@ -1002,7 +1002,7 @@
                                                             &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
             pxReturn->u.xTCP.usRemotePort = FreeRTOS_htons( pxTCPPacket->xTCPHeader.usSourcePort );
-            pxReturn->u.xTCP.ulRemoteIP = FreeRTOS_htonl( pxTCPPacket->xIPHeader.ulSourceIPAddress );
+            pxReturn->u.xTCP.xRemoteIP.xIP_IPv4 = FreeRTOS_htonl( pxTCPPacket->xIPHeader.ulSourceIPAddress );
             pxReturn->u.xTCP.xTCPWindow.ulOurSequenceNumber = ulInitialSequenceNumber;
 
             /* Here is the SYN action. */

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -140,13 +140,13 @@
                  * status 'eCLOSE_WAIT'. */
                 FreeRTOS_debug_printf( ( "Connect: giving up %xip:%u\n",
                                          ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, /* IP address of remote machine. */
-                                         pxSocket->u.xTCP.usRemotePort ) );        /* Port on remote machine. */
+                                         pxSocket->u.xTCP.usRemotePort ) );                /* Port on remote machine. */
                 vTCPStateChange( pxSocket, eCLOSE_WAIT );
             }
             else if( prvTCPMakeSurePrepared( pxSocket ) == pdTRUE )
             {
                 ProtocolHeaders_t * pxProtocolHeaders;
-                const UBaseType_t uxHeaderSize = ipSIZE_OF_IPv4_HEADER;
+                const UBaseType_t uxHeaderSize = uxIPHeaderSizeSocket( pxSocket );
 
                 /* Or else, if the connection has been prepared, or can be prepared
                  * now, proceed to send the packet with the SYN flag.
@@ -403,7 +403,7 @@
                     {
                         /* Suppress FIN in case this packet carries earlier data to be
                          * retransmitted. */
-                        uint32_t ulDataLen = ( uint32_t ) ( ulLen - ( ipSIZE_OF_TCP_HEADER + ipSIZE_OF_IPv4_HEADER ) );
+                        uint32_t ulDataLen = ( uint32_t ) ( ulLen - ( ipSIZE_OF_TCP_HEADER + uxIPHeaderSizePacket( pxNetworkBuffer ) ) );
 
                         if( ( pxTCPWindow->ulOurSequenceNumber + ulDataLen ) != pxTCPWindow->tx.ulFINSequenceNumber )
                         {
@@ -467,7 +467,7 @@
                 {
                     /* calculate the IP header checksum, in case the driver won't do that. */
                     pxIPHeader->usHeaderChecksum = 0x00U;
-                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), uxIPHeaderSizePacket( pxNetworkBuffer ) );
                     pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
                     /* calculate the TCP checksum for an outgoing packet. */
@@ -1090,7 +1090,7 @@
                     {
                         FreeRTOS_debug_printf( ( "keep-alive: giving up %xip:%u\n",
                                                  ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, /* IP address of remote machine. */
-                                                 pxSocket->u.xTCP.usRemotePort ) );        /* Port on remote machine. */
+                                                 pxSocket->u.xTCP.usRemotePort ) );                /* Port on remote machine. */
                         vTCPStateChange( pxSocket, eCLOSE_WAIT );
                         lDataLen = -1;
                     }
@@ -1313,7 +1313,7 @@
         BaseType_t xSendLength = xByteCount;
         uint32_t ulRxBufferSpace;
         /* Two steps to please MISRA. */
-        size_t uxSize = ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER;
+        size_t uxSize = uxIPHeaderSizePacket( *ppxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER;
         BaseType_t xSizeWithoutData = ( BaseType_t ) uxSize;
 
         #if ( ipconfigUSE_TCP_WIN == 1 )
@@ -1462,7 +1462,7 @@
                 /* coverity[misra_c_2012_rule_11_3_violation] */
                 TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
                 const uint32_t ulSendLength =
-                    ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ); /* Plus 0 options. */
+                    ( uxIPHeaderSizePacket( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ); /* Plus 0 options. */
 
                 pxTCPPacket->xTCPHeader.ucTCPFlags = ucTCPFlags;
                 pxTCPPacket->xTCPHeader.ucTCPOffset = ( ipSIZE_OF_TCP_HEADER ) << 2;

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -139,7 +139,7 @@
                  * to most 3 times.  When there is no response, the socket get the
                  * status 'eCLOSE_WAIT'. */
                 FreeRTOS_debug_printf( ( "Connect: giving up %xip:%u\n",
-                                         ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, /* IP address of remote machine. */
+                                         ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, /* IP address of remote machine. */
                                          pxSocket->u.xTCP.usRemotePort ) );        /* Port on remote machine. */
                 vTCPStateChange( pxSocket, eCLOSE_WAIT );
             }
@@ -615,7 +615,7 @@
             }
         #endif /* ipconfigHAS_PRINTF != 0 */
 
-        ulRemoteIP = FreeRTOS_htonl( pxSocket->u.xTCP.ulRemoteIP );
+        ulRemoteIP = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 );
 
         /* Determine the ARP cache status for the requested IP address. */
         eReturned = eARPGetCacheEntry( &( ulRemoteIP ), &( xEthAddress ) );
@@ -632,7 +632,7 @@
                 pxSocket->u.xTCP.ucRepCount++;
 
                 FreeRTOS_debug_printf( ( "ARP for %xip (using %xip): rc=%d %02X:%02X:%02X %02X:%02X:%02X\n",
-                                         ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
+                                         ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
                                          ( unsigned ) FreeRTOS_htonl( ulRemoteIP ),
                                          eReturned,
                                          xEthAddress.ucBytes[ 0 ],
@@ -653,7 +653,7 @@
             /* Get a difficult-to-predict initial sequence number for this 4-tuple. */
             ulInitialSequenceNumber = ulApplicationGetNextSequenceNumber( *ipLOCAL_IP_ADDRESS_POINTER,
                                                                           pxSocket->usLocalPort,
-                                                                          pxSocket->u.xTCP.ulRemoteIP,
+                                                                          pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
                                                                           pxSocket->u.xTCP.usRemotePort );
 
             /* Check for a random number generation error. */
@@ -704,7 +704,7 @@
             /* Addresses and ports will be stored swapped because prvTCPReturnPacket
              * will swap them back while replying. */
             pxIPHeader->ulDestinationIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
-            pxIPHeader->ulSourceIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.ulRemoteIP );
+            pxIPHeader->ulSourceIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 );
 
             pxTCPPacket->xTCPHeader.usSourcePort = FreeRTOS_htons( pxSocket->u.xTCP.usRemotePort );
             pxTCPPacket->xTCPHeader.usDestinationPort = FreeRTOS_htons( pxSocket->usLocalPort );
@@ -1089,7 +1089,7 @@
                     if( pxSocket->u.xTCP.ucKeepRepCount > 3U ) /*_RB_ Magic number. */
                     {
                         FreeRTOS_debug_printf( ( "keep-alive: giving up %xip:%u\n",
-                                                 ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, /* IP address of remote machine. */
+                                                 ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, /* IP address of remote machine. */
                                                  pxSocket->u.xTCP.usRemotePort ) );        /* Port on remote machine. */
                         vTCPStateChange( pxSocket, eCLOSE_WAIT );
                         lDataLen = -1;
@@ -1115,7 +1115,7 @@
                             if( xTCPWindowLoggingLevel != 0 )
                             {
                                 FreeRTOS_debug_printf( ( "keep-alive: %xip:%u count %u\n",
-                                                         ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
+                                                         ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
                                                          pxSocket->u.xTCP.usRemotePort,
                                                          pxSocket->u.xTCP.ucKeepRepCount ) );
                             }

--- a/source/FreeRTOS_TCP_Utils.c
+++ b/source/FreeRTOS_TCP_Utils.c
@@ -102,14 +102,14 @@
             }
         #endif
 
-        if( ( ( FreeRTOS_ntohl( pxSocket->u.xTCP.ulRemoteIP ) ^ *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) != 0U )
+        if( ( ( FreeRTOS_ntohl( pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 ) ^ *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) != 0U )
         {
             /* Data for this peer will pass through a router, and maybe through
              * the internet.  Limit the MSS to 1400 bytes or less. */
             ulMSS = FreeRTOS_min_uint32( ( uint32_t ) tcpREDUCED_MSS_THROUGH_INTERNET, ulMSS );
         }
 
-        FreeRTOS_debug_printf( ( "prvSocketSetMSS: %u bytes for %xip:%u\n", ( unsigned ) ulMSS, ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, pxSocket->u.xTCP.usRemotePort ) );
+        FreeRTOS_debug_printf( ( "prvSocketSetMSS: %u bytes for %xip:%u\n", ( unsigned ) ulMSS, ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, pxSocket->u.xTCP.usRemotePort ) );
 
         pxSocket->u.xTCP.usMSS = ( uint16_t ) ulMSS;
     }

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -228,7 +228,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
                 {
                     pxIPHeader->usHeaderChecksum = 0U;
-                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), uxIPHeaderSizePacket( pxNetworkBuffer ) );
                     pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
                     if( ( ucSocketOptions & ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT ) != 0U )

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -96,7 +96,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
     UDPPacket_t * pxUDPPacket;
     IPHeader_t * pxIPHeader;
     eARPLookupResult_t eReturned;
-    uint32_t ulIPAddress = pxNetworkBuffer->ulIPAddress;
+    uint32_t ulIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
     size_t uxPayloadSize;
     /* memcpy() helper variables for MISRA Rule 21.15 compliance*/
     const void * pvCopySource;
@@ -130,7 +130,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
                 uint8_t ucSocketOptions;
             #endif
-            iptraceSENDING_UDP_PACKET( pxNetworkBuffer->ulIPAddress );
+            iptraceSENDING_UDP_PACKET( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
 
             /* Create short cuts to the data within the packet. */
             pxIPHeader = &( pxUDPPacket->xIPHeader );
@@ -203,7 +203,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             }
 
             pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
-            pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->ulIPAddress;
+            pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
 
             /* The stack doesn't support fragments, so the fragment offset field must always be zero.
              * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
@@ -218,7 +218,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
                 {
                     /* LLMNR messages are typically used on a LAN and they're
                      * not supposed to cross routers */
-                    if( pxNetworkBuffer->ulIPAddress == ipLLMNR_IP_ADDR )
+                    if( pxNetworkBuffer->xIPAddress.xIP_IPv4 == ipLLMNR_IP_ADDR )
                     {
                         pxIPHeader->ucTimeToLive = 0x01;
                     }
@@ -250,8 +250,8 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             vARPRefreshCacheEntry( NULL, ulIPAddress );
 
             /* Generate an ARP for the required IP address. */
-            iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->ulIPAddress );
-            pxNetworkBuffer->ulIPAddress = ulIPAddress;
+            iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
+            pxNetworkBuffer->xIPAddress.xIP_IPv4 = ulIPAddress;
             vARPGenerateRequestPacket( pxNetworkBuffer );
         }
         else
@@ -366,7 +366,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                         void * pcData = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
                         FOnUDPReceive_t xHandler = ( FOnUDPReceive_t ) pxSocket->u.xUDP.pxHandleReceive;
                         xSourceAddress.sin_port = pxNetworkBuffer->usPort;
-                        xSourceAddress.sin_addr = pxNetworkBuffer->ulIPAddress;
+                        xSourceAddress.sin_addr = pxNetworkBuffer->xIPAddress.xIP_IPv4;
                         destinationAddress.sin_port = usPort;
                         destinationAddress.sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
 

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -214,14 +214,14 @@
 
 /* Include all API's and code that is needed for the IPv4 protocol.
  * When defined as zero, the application should uses IPv6. */
-#ifndef ipconfigUSE_IPv4
-    #define ipconfigUSE_IPv4    ( 1 )
+#ifndef ipconfigUSE_IPV4
+    #define ipconfigUSE_IPV4    ( 1 )
 #endif
 
 /* Include all API's and code that is needed for the IPv6 protocol.
  * When defined as zero, the application should uses IPv4. */
-#ifndef ipconfigUSE_IPv6
-    #define ipconfigUSE_IPv6    ( 1 )
+#ifndef ipconfigUSE_IPV6
+    #define ipconfigUSE_IPV6    ( 1 )
 #endif
 
 /* Determine the number of clock ticks that the API's FreeRTOS_recv() and

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -57,7 +57,6 @@
 /* The size of the Ethernet header is 14, meaning that 802.1Q VLAN tags
  * are not ( yet ) supported. */
 #define ipSIZE_OF_ETH_HEADER     14U
-#define ipSIZE_OF_IPv4_HEADER    20U
 #define ipSIZE_OF_IGMP_HEADER    8U
 #define ipSIZE_OF_UDP_HEADER     8U
 #define ipSIZE_OF_TCP_HEADER     20U

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -55,11 +55,11 @@
 
 /* The size of the Ethernet header is 14, meaning that 802.1Q VLAN tags
  * are not ( yet ) supported. */
-#define ipSIZE_OF_ETH_HEADER      14U
-#define ipSIZE_OF_IPv4_HEADER     20U
-#define ipSIZE_OF_IGMP_HEADER     8U
-#define ipSIZE_OF_UDP_HEADER      8U
-#define ipSIZE_OF_TCP_HEADER      20U
+#define ipSIZE_OF_ETH_HEADER     14U
+#define ipSIZE_OF_IPv4_HEADER    20U
+#define ipSIZE_OF_IGMP_HEADER    8U
+#define ipSIZE_OF_UDP_HEADER     8U
+#define ipSIZE_OF_TCP_HEADER     20U
 
 
 /*
@@ -117,21 +117,21 @@ extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 #endif
 
 /* The offset of ucTCPFlags within the TCP header. */
-#define ipTCP_FLAGS_OFFSET       13U
+#define ipTCP_FLAGS_OFFSET      13U
 
 /** @brief Returned to indicate a valid checksum. */
-#define ipCORRECT_CRC            0xffffU
+#define ipCORRECT_CRC           0xffffU
 
 /** @brief Returned to indicate incorrect checksum. */
-#define ipWRONG_CRC              0x0000U
+#define ipWRONG_CRC             0x0000U
 
 /** @brief Returned as the (invalid) checksum when the length of the data being checked
  * had an invalid length. */
-#define ipINVALID_LENGTH         0x1234U
+#define ipINVALID_LENGTH        0x1234U
 
 /** @brief Returned as the (invalid) checksum when the protocol being checked is not
  * handled.  The value is chosen simply to be easy to spot when debugging. */
-#define ipUNHANDLED_PROTOCOL     0x4321U
+#define ipUNHANDLED_PROTOCOL    0x4321U
 
 /** @brief The maximum time the IP task is allowed to remain in the Blocked state if no
  * events are posted to the network event queue. */
@@ -415,8 +415,13 @@ extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
 #endif
 
 #include "FreeRTOS_IP_Utils.h"
-#include "FreeRTOS_IPv4.h"
-#include "FreeRTOS_IPv6.h"
+
+#if ipconfigUSE_IPV4
+    #include "FreeRTOS_IPv4.h"
+#endif /* ipconfigUSE_IPV4 */
+#if ipconfigUSE_IPV6
+    #include "FreeRTOS_IPv6.h"
+#endif /* ipconfigUSE_IPV6 */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -40,6 +40,7 @@
 /* Application level configuration options. */
 #include "FreeRTOSIPConfig.h"
 #include "FreeRTOSIPConfigDefaults.h"
+#include "FreeRTOS_IP_Common.h"
 #include "IPTraceMacroDefaults.h"
 
 /* Constants defining the current version of the FreeRTOS+TCP
@@ -149,6 +150,7 @@ extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 #endif
 
 
+
 /**
  * The structure used to store buffers and pass them around the network stack.
  * Buffers can be in use by the stack, in use by the network interface hardware
@@ -157,7 +159,7 @@ extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 typedef struct xNETWORK_BUFFER
 {
     ListItem_t xBufferListItem;                /**< Used to reference the buffer form the free buffer list or a socket. */
-    uint32_t ulIPAddress;                      /**< Source or destination IP address, depending on usage scenario. */
+    IP_Address_t xIPAddress;                   /**< Source or destination IP address, depending on usage scenario. */
     uint8_t * pucEthernetBuffer;               /**< Pointer to the start of the Ethernet frame. */
     size_t xDataLength;                        /**< Starts by holding the total Ethernet frame length, then the UDP/TCP payload length. */
     uint16_t usPort;                           /**< Source or destination port, depending on usage scenario. */

--- a/source/include/FreeRTOS_IP_Common.h
+++ b/source/include/FreeRTOS_IP_Common.h
@@ -1,0 +1,57 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef FREERTOS_IP_COMMON_H
+#define FREERTOS_IP_COMMON_H
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
+struct xIPv6_Address
+{
+    uint8_t ucBytes[ 16 ];
+};
+
+typedef struct xIPv6_Address IPv6_Address_t;
+
+typedef union IP_Address
+{
+    uint32_t xIP_IPv4;       /**< IPv4 address */
+    IPv6_Address_t xIP_IPv6; /**< IPv6 address */
+} IP_Address_t;
+
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
+
+#endif /* FREERTOS_IP_COMMON_H */

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -741,6 +741,16 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
  */
 NetworkBufferDescriptor_t * pxUDPPayloadBuffer_to_NetworkBuffer( const void * pvBuffer );
 
+/* Get the size of the IP-header.
+ * 'usFrameType' must be filled in if IPv6is to be recognised. */
+size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
+/*-----------------------------------------------------------*/
+
+/* Get the size of the IP-header.
+ * The socket is checked for its type: IPv4 or IPv6. */
+size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket );
+/*-----------------------------------------------------------*/
+
 /*
  * Internal: Sets a new state for a TCP socket and performs the necessary
  * actions like calling a OnConnected handler to notify the socket owner.

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -215,7 +215,7 @@ typedef struct IP_TASK_COMMANDS
 struct xPacketSummary
 {
     BaseType_t xIsIPv6;                          /**< pdTRUE for IPv6 packets. */
-    #if ( ipconfigUSE_IPv6 != 0 )
+    #if ipconfigUSE_IPV6
         const IPHeader_IPv6_t * pxIPPacket_IPv6; /**< A pointer to the IPv6 header. */
     #endif
     #if ( ipconfigHAS_DEBUG_PRINTF != 0 )

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -155,8 +155,12 @@ struct xTCP_HEADER
 #include "pack_struct_end.h"
 typedef struct xTCP_HEADER TCPHeader_t;
 
-#include "FreeRTOS_IPv4_Private.h"
-#include "FreeRTOS_IPv6_Private.h"
+#if ipconfigUSE_IPV4
+    #include "FreeRTOS_IPv4_Private.h"
+#endif /* ipconfigUSE_IPV4 */
+#if ipconfigUSE_IPV6
+    #include "FreeRTOS_IPv6_Private.h"
+#endif /* ipconfigUSE_IPV6 */
 
 /**
  * Union for the protocol packet to save space. Any packet cannot have more than one

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -73,8 +73,6 @@ uint32_t FreeRTOS_GetDNSServerAddress( void );
 uint32_t FreeRTOS_GetNetmask( void );
 uint32_t FreeRTOS_GetIPAddress( void );
 
-void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress );
-
 /* Set the MAC-address that belongs to a given IPv4 multi-cast address. */
 void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
                                   MACAddress_t * pxMACAddress );

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -34,8 +34,6 @@
 #endif
 /* *INDENT-ON* */
 
-#if ipconfigUSE_IPv4
-
 #include "FreeRTOS.h"
 #include "task.h"
 #include "FreeRTOS_IP.h"
@@ -57,7 +55,7 @@
 #define ipLAST_LOOPBACK_IPv4         0x80000000UL                /**< Highest IPv4 loopback address (excluding). */
 
 /*
- *  _HT_ : these functions come from the IPv4-only library.
+ *  These functions come from the IPv4-only library.
  *  They should get an extra parameter, the end-point
  *  void FreeRTOS_SetIPAddress( uint32_t ulIPAddress );
  *  void FreeRTOS_SetNetmask( uint32_t ulNetmask );
@@ -86,10 +84,10 @@ void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
 
 void FreeRTOS_ClearARP( void );
 
-/* _HT_ Temporary: show all valid ARP entries
+/* Show all valid ARP entries
  */
 #if ( ipconfigHAS_PRINTF != 0 ) || ( ipconfigHAS_DEBUG_PRINTF != 0 )
-void FreeRTOS_PrintARPCache( void );
+    void FreeRTOS_PrintARPCache( void );
 #endif
 
 /* Return pdTRUE if the IPv4 address is a multicast address. */
@@ -100,8 +98,6 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress );
  * only be called from an application. */
 BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
                                TickType_t uxTicksToWait );
-
-#endif /* ipconfigUSE_IPv4 */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -159,6 +159,11 @@ struct xTCP_PACKET
 #include "pack_struct_end.h"
 typedef struct xTCP_PACKET TCPPacket_t;
 
+/*
+ * Processes incoming ARP packets.
+ */
+eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame );
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -38,6 +38,8 @@
 /* The maximum UDP payload length. */
 #define ipMAX_UDP_PAYLOAD_LENGTH        ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
 
+#define TCP_PACKET_SIZE                 ( sizeof( TCPPacket_t ) )
+
 /* The offset into an IP packet into which the IP data (payload) starts. */
 #define ipIP_PAYLOAD_OFFSET             ( sizeof( IPPacket_t ) )
 /* The offset into a UDP packet at which the UDP data (payload) starts. */

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -33,59 +33,57 @@
 #endif
 /* *INDENT-ON* */
 
-#if ipconfigUSE_IPv4
-
 #include "FreeRTOS_IP_Private.h"
 
 /* The maximum UDP payload length. */
-#define ipMAX_UDP_PAYLOAD_LENGTH               ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
+#define ipMAX_UDP_PAYLOAD_LENGTH        ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
 
 /* The offset into an IP packet into which the IP data (payload) starts. */
-#define ipIP_PAYLOAD_OFFSET                    ( sizeof( IPPacket_t ) )
+#define ipIP_PAYLOAD_OFFSET             ( sizeof( IPPacket_t ) )
 /* The offset into a UDP packet at which the UDP data (payload) starts. */
-#define ipUDP_PAYLOAD_OFFSET_IPv4              ( sizeof( UDPPacket_t ) )
+#define ipUDP_PAYLOAD_OFFSET_IPv4       ( sizeof( UDPPacket_t ) )
 /* The value of 'ipUDP_PAYLOAD_IP_TYPE_OFFSET' is 42 + 6 = 48 bytes. */
-#define ipUDP_PAYLOAD_IP_TYPE_OFFSET           ( sizeof( UDPPacket_t ) + ipIP_TYPE_OFFSET )
+#define ipUDP_PAYLOAD_IP_TYPE_OFFSET    ( sizeof( UDPPacket_t ) + ipIP_TYPE_OFFSET )
 
 #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
 
 /* Ethernet frame types. */
-    #define ipARP_FRAME_TYPE                   ( 0x0608U )
-    #define ipIPv4_FRAME_TYPE                  ( 0x0008U )
+    #define ipARP_FRAME_TYPE                ( 0x0608U )
+    #define ipIPv4_FRAME_TYPE               ( 0x0008U )
 
 /* ARP related definitions. */
-    #define ipARP_PROTOCOL_TYPE                ( 0x0008U )
-    #define ipARP_HARDWARE_TYPE_ETHERNET       ( 0x0100U )
-    #define ipARP_REQUEST                      ( 0x0100U )
-    #define ipARP_REPLY                        ( 0x0200U )
+    #define ipARP_PROTOCOL_TYPE             ( 0x0008U )
+    #define ipARP_HARDWARE_TYPE_ETHERNET    ( 0x0100U )
+    #define ipARP_REQUEST                   ( 0x0100U )
+    #define ipARP_REPLY                     ( 0x0200U )
 
 #else /* if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
 
 /* Ethernet frame types. */
-    #define ipARP_FRAME_TYPE                   ( 0x0806U )
-    #define ipIPv4_FRAME_TYPE                  ( 0x0800U )
+    #define ipARP_FRAME_TYPE                ( 0x0806U )
+    #define ipIPv4_FRAME_TYPE               ( 0x0800U )
 
 /* ARP related definitions. */
-    #define ipARP_PROTOCOL_TYPE                ( 0x0800U )
-    #define ipARP_HARDWARE_TYPE_ETHERNET       ( 0x0001U )
-    #define ipARP_REQUEST                      ( 0x0001 )
-    #define ipARP_REPLY                        ( 0x0002 )
+    #define ipARP_PROTOCOL_TYPE             ( 0x0800U )
+    #define ipARP_HARDWARE_TYPE_ETHERNET    ( 0x0001U )
+    #define ipARP_REQUEST                   ( 0x0001 )
+    #define ipARP_REPLY                     ( 0x0002 )
 
 #endif /* ipconfigBYTE_ORDER */
 
 #include "pack_struct_start.h"
 struct xIP_HEADER
 {
-	uint8_t ucVersionHeaderLength;    /**< The version field + internet header length 0 + 1 =  1 */
-	uint8_t ucDifferentiatedServicesCode; /**< Differentiated services code point + ECN    1 + 1 =  2 */
-	uint16_t usLength;                /**< Entire Packet size, ex. Ethernet header.   2 + 2 =  4 */
-	uint16_t usIdentification;        /**< Identification field                       4 + 2 =  6 */
-	uint16_t usFragmentOffset;        /**< Fragment flags and fragment offset         6 + 2 =  8 */
-	uint8_t ucTimeToLive;             /**< Time to live field                         8 + 1 =  9 */
-	uint8_t ucProtocol;               /**< Protocol used in the IP-datagram           9 + 1 = 10 */
-	uint16_t usHeaderChecksum;        /**< Checksum of the IP-header                 10 + 2 = 12 */
-	uint32_t ulSourceIPAddress;       /**< IP address of the source                  12 + 4 = 16 */
-	uint32_t ulDestinationIPAddress;  /**< IP address of the destination             16 + 4 = 20 */
+    uint8_t ucVersionHeaderLength;        /**< The version field + internet header length 0 + 1 =  1 */
+    uint8_t ucDifferentiatedServicesCode; /**< Differentiated services code point + ECN    1 + 1 =  2 */
+    uint16_t usLength;                    /**< Entire Packet size, ex. Ethernet header.   2 + 2 =  4 */
+    uint16_t usIdentification;            /**< Identification field                       4 + 2 =  6 */
+    uint16_t usFragmentOffset;            /**< Fragment flags and fragment offset         6 + 2 =  8 */
+    uint8_t ucTimeToLive;                 /**< Time to live field                         8 + 1 =  9 */
+    uint8_t ucProtocol;                   /**< Protocol used in the IP-datagram           9 + 1 = 10 */
+    uint16_t usHeaderChecksum;            /**< Checksum of the IP-header                 10 + 2 = 12 */
+    uint32_t ulSourceIPAddress;           /**< IP address of the source                  12 + 4 = 16 */
+    uint32_t ulDestinationIPAddress;      /**< IP address of the destination             16 + 4 = 20 */
 }
 #include "pack_struct_end.h"
 typedef struct xIP_HEADER IPHeader_t;
@@ -93,15 +91,15 @@ typedef struct xIP_HEADER IPHeader_t;
 #include "pack_struct_start.h"
 struct xARP_HEADER
 {
-	uint16_t usHardwareType;          /**< Network Link Protocol type                     0 +  2 =  2 */
-	uint16_t usProtocolType;          /**< The internetwork protocol                      2 +  2 =  4 */
-	uint8_t ucHardwareAddressLength;  /**< Length in octets of a hardware address         4 +  1 =  5 */
-	uint8_t ucProtocolAddressLength;  /**< Length in octets of the internetwork protocol  5 +  1 =  6 */
-	uint16_t usOperation;             /**< Operation that the sender is performing        6 +  2 =  8 */
-	MACAddress_t xSenderHardwareAddress; /**< Media address of the sender                    8 +  6 = 14 */
-	uint8_t ucSenderProtocolAddress[ 4 ]; /**< Internetwork address of sender                14 +  4 = 18  */
-	MACAddress_t xTargetHardwareAddress; /**< Media address of the intended receiver        18 +  6 = 24  */
-	uint32_t ulTargetProtocolAddress; /**< Internetwork address of the intended receiver 24 +  4 = 28  */
+    uint16_t usHardwareType;              /**< Network Link Protocol type                     0 +  2 =  2 */
+    uint16_t usProtocolType;              /**< The internetwork protocol                      2 +  2 =  4 */
+    uint8_t ucHardwareAddressLength;      /**< Length in octets of a hardware address         4 +  1 =  5 */
+    uint8_t ucProtocolAddressLength;      /**< Length in octets of the internetwork protocol  5 +  1 =  6 */
+    uint16_t usOperation;                 /**< Operation that the sender is performing        6 +  2 =  8 */
+    MACAddress_t xSenderHardwareAddress;  /**< Media address of the sender                    8 +  6 = 14 */
+    uint8_t ucSenderProtocolAddress[ 4 ]; /**< Internetwork address of sender                14 +  4 = 18  */
+    MACAddress_t xTargetHardwareAddress;  /**< Media address of the intended receiver        18 +  6 = 24  */
+    uint32_t ulTargetProtocolAddress;     /**< Internetwork address of the intended receiver 24 +  4 = 28  */
 }
 #include "pack_struct_end.h"
 typedef struct xARP_HEADER ARPHeader_t;
@@ -113,8 +111,8 @@ typedef struct xARP_HEADER ARPHeader_t;
 #include "pack_struct_start.h"
 struct xARP_PACKET
 {
-	EthernetHeader_t xEthernetHeader; /**< The ethernet header of an ARP Packet  0 + 14 = 14 */
-	ARPHeader_t xARPHeader;       /**< The ARP header of an ARP Packet       14 + 28 = 42 */
+    EthernetHeader_t xEthernetHeader; /**< The ethernet header of an ARP Packet  0 + 14 = 14 */
+    ARPHeader_t xARPHeader;           /**< The ARP header of an ARP Packet       14 + 28 = 42 */
 }
 #include "pack_struct_end.h"
 typedef struct xARP_PACKET ARPPacket_t;
@@ -122,8 +120,8 @@ typedef struct xARP_PACKET ARPPacket_t;
 #include "pack_struct_start.h"
 struct xIP_PACKET
 {
-	EthernetHeader_t xEthernetHeader;
-	IPHeader_t xIPHeader;
+    EthernetHeader_t xEthernetHeader;
+    IPHeader_t xIPHeader;
 }
 #include "pack_struct_end.h"
 typedef struct xIP_PACKET IPPacket_t;
@@ -131,9 +129,9 @@ typedef struct xIP_PACKET IPPacket_t;
 #include "pack_struct_start.h"
 struct xICMP_PACKET
 {
-	EthernetHeader_t xEthernetHeader; /**< The Ethernet header of an ICMP packet. */
-	IPHeader_t xIPHeader;         /**< The IP header of an ICMP packet. */
-	ICMPHeader_t xICMPHeader;     /**< The ICMP header of an ICMP packet. */
+    EthernetHeader_t xEthernetHeader; /**< The Ethernet header of an ICMP packet. */
+    IPHeader_t xIPHeader;             /**< The IP header of an ICMP packet. */
+    ICMPHeader_t xICMPHeader;         /**< The ICMP header of an ICMP packet. */
 }
 #include "pack_struct_end.h"
 typedef struct xICMP_PACKET ICMPPacket_t;
@@ -142,9 +140,9 @@ typedef struct xICMP_PACKET ICMPPacket_t;
 #include "pack_struct_start.h"
 struct xUDP_PACKET
 {
-	EthernetHeader_t xEthernetHeader; /**< UDP-Packet ethernet header  0 + 14 = 14 */
-	IPHeader_t xIPHeader;         /**< UDP-Packet IP header        14 + 20 = 34 */
-	UDPHeader_t xUDPHeader;       /**< UDP-Packet UDP header       34 +  8 = 42 */
+    EthernetHeader_t xEthernetHeader; /**< UDP-Packet ethernet header  0 + 14 = 14 */
+    IPHeader_t xIPHeader;             /**< UDP-Packet IP header        14 + 20 = 34 */
+    UDPHeader_t xUDPHeader;           /**< UDP-Packet UDP header       34 +  8 = 42 */
 }
 #include "pack_struct_end.h"
 typedef struct xUDP_PACKET UDPPacket_t;
@@ -152,14 +150,12 @@ typedef struct xUDP_PACKET UDPPacket_t;
 #include "pack_struct_start.h"
 struct xTCP_PACKET
 {
-	EthernetHeader_t xEthernetHeader; /**< The ethernet header  0 + 14 = 14 */
-	IPHeader_t xIPHeader;         /**< The IP header        14 + 20 = 34 */
-	TCPHeader_t xTCPHeader;       /**< The TCP header       34 + 32 = 66 */
+    EthernetHeader_t xEthernetHeader; /**< The ethernet header  0 + 14 = 14 */
+    IPHeader_t xIPHeader;             /**< The IP header        14 + 20 = 34 */
+    TCPHeader_t xTCPHeader;           /**< The TCP header       34 + 32 = 66 */
 }
 #include "pack_struct_end.h"
 typedef struct xTCP_PACKET TCPPacket_t;
-
-#endif /* ipconfigUSE_IPv4 */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -35,6 +35,7 @@
 #include "FreeRTOS.h"
 #include "task.h"
 #include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Common.h"
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -32,63 +32,61 @@
 #endif
 /* *INDENT-ON* */
 
-#if ipconfigUSE_IPv6
-
 #include "FreeRTOS.h"
 #include "task.h"
 #include "FreeRTOS_IP.h"
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */
-#define ipSIZE_OF_IPv6_HEADER                      40U
-#define ipSIZE_OF_ICMPv6_HEADER                    24U
+#define ipSIZE_OF_IPv6_HEADER                    40U
+#define ipSIZE_OF_ICMPv6_HEADER                  24U
 
-#define ipSIZE_OF_IPv6_ADDRESS                     16U
+#define ipSIZE_OF_IPv6_ADDRESS                   16U
 
-#define ipPROTOCOL_ICMP_IPv6                       ( 58U )
-#define ipTYPE_IPv6                                ( 0x60U )
+#define ipPROTOCOL_ICMP_IPv6                     ( 58U )
+#define ipTYPE_IPv6                              ( 0x60U )
 
 /* Some IPv6 ICMP requests. */
-#define ipICMP_DEST_UNREACHABLE_IPv6               ( ( uint8_t ) 1U )
-#define ipICMP_PACKET_TOO_BIG_IPv6                 ( ( uint8_t ) 2U )
-#define ipICMP_TIME_EXEEDED_IPv6                   ( ( uint8_t ) 3U )
-#define ipICMP_PARAMETER_PROBLEM_IPv6              ( ( uint8_t ) 4U )
-#define ipICMP_PING_REQUEST_IPv6                   ( ( uint8_t ) 128U )
-#define ipICMP_PING_REPLY_IPv6                     ( ( uint8_t ) 129U )
-#define ipICMP_ROUTER_SOLICITATION_IPv6            ( ( uint8_t ) 133U )
-#define ipICMP_ROUTER_ADVERTISEMENT_IPv6           ( ( uint8_t ) 134U )
-#define ipICMP_NEIGHBOR_SOLICITATION_IPv6          ( ( uint8_t ) 135U )
-#define ipICMP_NEIGHBOR_ADVERTISEMENT_IPv6         ( ( uint8_t ) 136U )
+#define ipICMP_DEST_UNREACHABLE_IPv6             ( ( uint8_t ) 1U )
+#define ipICMP_PACKET_TOO_BIG_IPv6               ( ( uint8_t ) 2U )
+#define ipICMP_TIME_EXEEDED_IPv6                 ( ( uint8_t ) 3U )
+#define ipICMP_PARAMETER_PROBLEM_IPv6            ( ( uint8_t ) 4U )
+#define ipICMP_PING_REQUEST_IPv6                 ( ( uint8_t ) 128U )
+#define ipICMP_PING_REPLY_IPv6                   ( ( uint8_t ) 129U )
+#define ipICMP_ROUTER_SOLICITATION_IPv6          ( ( uint8_t ) 133U )
+#define ipICMP_ROUTER_ADVERTISEMENT_IPv6         ( ( uint8_t ) 134U )
+#define ipICMP_NEIGHBOR_SOLICITATION_IPv6        ( ( uint8_t ) 135U )
+#define ipICMP_NEIGHBOR_ADVERTISEMENT_IPv6       ( ( uint8_t ) 136U )
 
 
-#define ipIPv6_EXT_HEADER_HOP_BY_HOP               0U
-#define ipIPv6_EXT_HEADER_DESTINATION_OPTIONS      60U
-#define ipIPv6_EXT_HEADER_ROUTING_HEADER           43U
-#define ipIPv6_EXT_HEADER_FRAGMENT_HEADER          44U
-#define ipIPv6_EXT_HEADER_AUTHEN_HEADER            51U
-#define ipIPv6_EXT_HEADER_SECURE_PAYLOAD           50U
+#define ipIPv6_EXT_HEADER_HOP_BY_HOP             0U
+#define ipIPv6_EXT_HEADER_DESTINATION_OPTIONS    60U
+#define ipIPv6_EXT_HEADER_ROUTING_HEADER         43U
+#define ipIPv6_EXT_HEADER_FRAGMENT_HEADER        44U
+#define ipIPv6_EXT_HEADER_AUTHEN_HEADER          51U
+#define ipIPv6_EXT_HEADER_SECURE_PAYLOAD         50U
 /* Destination options may follow here in case there are no routing options. */
-#define ipIPv6_EXT_HEADER_MOBILITY_HEADER          135U
+#define ipIPv6_EXT_HEADER_MOBILITY_HEADER        135U
+
+#ifndef _MSC_VER
+    extern const struct xIPv6_Address in6addr_any;
+    extern const struct xIPv6_Address in6addr_loopback;
+#else
+
+/* Microsoft visual C already has these objects defined.
+ * Name them slightly different. */
+    extern const struct xIPv6_Address FreeRTOS_in6addr_any;
+    extern const struct xIPv6_Address FreeRTOS_in6addr_loopback;
+    #define in6addr_any         FreeRTOS_in6addr_any
+    #define in6addr_loopback    FreeRTOS_in6addr_loopback
+
+#endif
 
 /* A forward declaration of 'struct xNetworkEndPoint' and 'xNetworkInterface'.
  * The actual declaration can be found in FreeRTOS_Routing.h which is included
  * as the last +TCP header file. */
 struct xNetworkEndPoint;
 struct xNetworkInterface;
-
-#ifndef _MSC_VER
-extern const struct xIPv6_Address in6addr_any;
-extern const struct xIPv6_Address in6addr_loopback;
-#else
-
-/* Microsoft visual C already has these objects defined.
- * Name them slightly different. */
-extern const struct xIPv6_Address FreeRTOS_in6addr_any;
-extern const struct xIPv6_Address FreeRTOS_in6addr_loopback;
-    #define in6addr_any         FreeRTOS_in6addr_any
-    #define in6addr_loopback    FreeRTOS_in6addr_loopback
-
-#endif
 
 /* The last parameter is either ipTYPE_IPv4 or ipTYPE_IPv6. */
 void * FreeRTOS_GetUDPPayloadBufferv6( size_t uxRequestedSizeBytes,
@@ -142,8 +140,6 @@ BaseType_t xCompareIPv6_Address( const IPv6_Address_t * pxLeft,
 /* FreeRTOS_dnslookup6() returns pdTRUE when a host has been found. */
 uint32_t FreeRTOS_dnslookup6( const char * pcHostName,
                               IPv6_Address_t * pxAddress_IPv6 );
-
-#endif /* ipconfigUSE_IPv6 */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -109,6 +109,12 @@
 
 #define ipNUMERIC_CAST( TYPE, expression )    ( ( TYPE ) ( expression ) )
 
+
+/** @brief The macros vSetField16() and vSetField32() will write either a short or a 32-bit
+ * value into an array of bytes. They will be stored big-endian.
+ * The helper functions do the actual work.
+ */
+
 /*extern void vSetField16helper( uint8_t * pucBase,
  *                             size_t uxOffset,
  *                             uint16_t usValue );
@@ -250,21 +256,6 @@ FreeRTOS_Socket_t * pxTCPSocketLookupIPv6( UBaseType_t uxLocalPort,
                                            uint32_t ulRemoteIP,
                                            UBaseType_t uxRemotePort,
                                            IPv6_Address_t * pxAddress_IPv6 );
-
-/** @brief The macros vSetField16() and vSetField32() will write either a short or a 32-bit
- * value into an array of bytes. They will be stored big-endian.
- * The helper functions do the actual work.
- */
-
-/* Get the size of the IP-header.
- * 'usFrameType' must be filled in if IPv6is to be recognised. */
-size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
-/*-----------------------------------------------------------*/
-
-/* Get the size of the IP-header.
- * The socket is checked for its type: IPv4 or IPv6. */
-/*size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket ); */
-/*-----------------------------------------------------------*/
 
 #if ( ( ipconfigHAS_DEBUG_PRINTF != 0 ) || ( ipconfigHAS_PRINTF != 0 ) )
 /* prepare a string which describes a socket, just for logging. */

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -49,6 +49,9 @@
 
 #include "event_groups.h"
 
+/* MISRA Ref 20.5.1 [Use of undef] */
+/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-2051 */
+/* coverity[misra_c_2012_rule_20_5_violation] */
 #undef TCP_PACKET_SIZE
 #define TCP_PACKET_SIZE          ( sizeof( TCPPacket_IPv6_t ) )
 
@@ -58,7 +61,9 @@
 #define ipIP_TYPE_OFFSET         ( 6U )
 /* The offset into an IP packet into which the IP data (payload) starts. */
 #define ipIPv6_PAYLOAD_OFFSET    ( sizeof( IPPacket_IPv6_t ) )
-
+/* MISRA Ref 20.5.1 [Use of undef] */
+/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-2051 */
+/* coverity[misra_c_2012_rule_20_5_violation] */
 /* The maximum UDP payload length. */
 #undef ipMAX_UDP_PAYLOAD_LENGTH
 #define ipMAX_UDP_PAYLOAD_LENGTH          ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv6_HEADER ) - ipSIZE_OF_UDP_HEADER )
@@ -139,8 +144,7 @@ extern struct xNetworkEndPoint * pxNetworkEndPoints;
 /* A list of all network interfaces: */
 extern struct xNetworkInterface * pxNetworkInterfaces;
 
-typedef union xPROT_HEADERS   ProtocolHeaders_t;
-typedef struct xSOCKET        FreeRTOS_Socket_t;
+typedef struct xSOCKET FreeRTOS_Socket_t;
 
 #include "pack_struct_start.h"
 struct xIP_HEADER_IPv6

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -33,8 +33,6 @@
 #endif
 /* *INDENT-ON* */
 
-#if ipconfigUSE_IPv6
-
 /* Application level configuration options. */
 #include "FreeRTOSIPConfig.h"
 #include "FreeRTOSIPConfigDefaults.h"
@@ -53,24 +51,24 @@
 /* The offset from the UDP payload where the IP type will be stored.
  * For IPv4 packets, this it located 6 bytes before pucEthernetBuffer.
  * For IPv6 packets, this it located in the usual 'ucVersionTrafficClass'. */
-#define ipIP_TYPE_OFFSET                     ( 6U )
+#define ipIP_TYPE_OFFSET                  ( 6U )
 /* The offset into an IP packet into which the IP data (payload) starts. */
-#define ipIPv6_PAYLOAD_OFFSET                ( sizeof( IPPacket_IPv6_t ) )
+#define ipIPv6_PAYLOAD_OFFSET             ( sizeof( IPPacket_IPv6_t ) )
 
 /* The maximum UDP payload length. */
-#define ipMAX_UDP_PAYLOAD_LENGTH             ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
+#define ipMAX_UDP_PAYLOAD_LENGTH          ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
 /* The offset into a UDP packet at which the UDP data (payload) starts. */
-#define ipUDP_PAYLOAD_OFFSET_IPv6            ( sizeof( UDPPacket_IPv6_t ) )
+#define ipUDP_PAYLOAD_OFFSET_IPv6         ( sizeof( UDPPacket_IPv6_t ) )
 /* The value of 'ipUDP_PAYLOAD_IP_TYPE_OFFSET' is 42 + 6 = 48 bytes. */
-#define ipUDP_PAYLOAD_IPv6_TYPE_OFFSET       ( sizeof( UDPPacket_IPv6_t ) + ipIP_TYPE_OFFSET )
+#define ipUDP_PAYLOAD_IPv6_TYPE_OFFSET    ( sizeof( UDPPacket_IPv6_t ) + ipIP_TYPE_OFFSET )
 
 #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
 
-    #define ipIPv6_FRAME_TYPE                ( 0xDD86U )   /* Ethernet frame types. */
+    #define ipIPv6_FRAME_TYPE    ( 0xDD86U )               /* Ethernet frame types. */
 
 #else /* if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
 
-    #define ipIPv6_FRAME_TYPE                ( 0x86DDU )   /* Ethernet frame types. */
+    #define ipIPv6_FRAME_TYPE    ( 0x86DDU )               /* Ethernet frame types. */
 
 #endif /* ipconfigBYTE_ORDER */
 
@@ -91,7 +89,7 @@
  * The MISRA warnings can safely be suppressed because all casts are planned with care.
  */
 
-#define ipPOINTER_CAST( TYPE, pointer )       ( ( TYPE ) ( pointer ) )
+#define ipPOINTER_CAST( TYPE, pointer )    ( ( TYPE ) ( pointer ) )
 
 /* Sequence and ACK numbers are essentially unsigned (uint32_t). But when
  * a distance is calculated, it is useful to use signed numbers:
@@ -106,6 +104,19 @@
 
 #define ipNUMERIC_CAST( TYPE, expression )    ( ( TYPE ) ( expression ) )
 
+/*extern void vSetField16helper( uint8_t * pucBase,
+ *                             size_t uxOffset,
+ *                             uint16_t usValue );
+ #define vSetField16( pucBase, xType, xField, usValue ) \
+ *  vSetField16helper( pucBase, offsetof( xType, xField ), usValue )
+ *
+ * extern void vSetField32helper( uint8_t * pucBase,
+ *                             size_t uxOffset,
+ *                             uint32_t ulValue );
+ #define vSetField32( pucBase, xType, xField, ulValue ) \
+ *  vSetField32helper( pucBase, offsetof( xType, xField ), ulValue )
+ */
+
 /* As FreeRTOS_Routing is included later, use forward declarations
  * of the two structs. */
 struct xNetworkEndPoint;
@@ -117,13 +128,13 @@ extern struct xNetworkEndPoint * pxNetworkEndPoints;
 /* A list of all network interfaces: */
 extern struct xNetworkInterface * pxNetworkInterfaces;
 
-typedef union xPROT_HEADERS ProtocolHeaders_t;
-typedef struct xSOCKET FreeRTOS_Socket_t;
+typedef union xPROT_HEADERS   ProtocolHeaders_t;
+typedef struct xSOCKET        FreeRTOS_Socket_t;
 
 
 struct xIPv6_Address
 {
-	uint8_t ucBytes[ 16 ];
+    uint8_t ucBytes[ 16 ];
 };
 
 typedef struct xIPv6_Address IPv6_Address_t;
@@ -131,14 +142,14 @@ typedef struct xIPv6_Address IPv6_Address_t;
 #include "pack_struct_start.h"
 struct xIP_HEADER_IPv6
 {
-	uint8_t ucVersionTrafficClass;  /**< T  he version field.                      0 +  1 =  1 */
-	uint8_t ucTrafficClassFlow;     /**< Traffic class and flow.                 1 +  1 =  2 */
-	uint16_t usFlowLabel;           /**< Flow label.                             2 +  2 =  4 */
-	uint16_t usPayloadLength;       /**< Number of bytes after the IPv6 header.  4 +  2 =  6 */
-	uint8_t ucNextHeader;           /**< Next header: TCP, UDP, or ICMP.         6 +  1 =  7 */
-	uint8_t ucHopLimit;             /**< Replaces the time to live from IPv4.    7 +  1 =  8 */
-	IPv6_Address_t xSourceAddress;  /**< The IPv6 address of the sender.         8 + 16 = 24 */
-	IPv6_Address_t xDestinationAddress; /**< The IPv6 address of the receiver.      24 + 16 = 40 */
+    uint8_t ucVersionTrafficClass;      /**< T  he version field.                      0 +  1 =  1 */
+    uint8_t ucTrafficClassFlow;         /**< Traffic class and flow.                 1 +  1 =  2 */
+    uint16_t usFlowLabel;               /**< Flow label.                             2 +  2 =  4 */
+    uint16_t usPayloadLength;           /**< Number of bytes after the IPv6 header.  4 +  2 =  6 */
+    uint8_t ucNextHeader;               /**< Next header: TCP, UDP, or ICMP.         6 +  1 =  7 */
+    uint8_t ucHopLimit;                 /**< Replaces the time to live from IPv4.    7 +  1 =  8 */
+    IPv6_Address_t xSourceAddress;      /**< The IPv6 address of the sender.         8 + 16 = 24 */
+    IPv6_Address_t xDestinationAddress; /**< The IPv6 address of the receiver.      24 + 16 = 40 */
 }
 #include "pack_struct_end.h"
 typedef struct xIP_HEADER_IPv6 IPHeader_IPv6_t;
@@ -146,14 +157,14 @@ typedef struct xIP_HEADER_IPv6 IPHeader_IPv6_t;
 #include "pack_struct_start.h"
 struct xICMPHeader_IPv6
 {
-	uint8_t ucTypeOfMessage; /**< The message type.     0 +  1 = 1 */
-	uint8_t ucTypeOfService; /**< Type of service.      1 +  1 = 2 */
-	uint16_t usChecksum;     /**< Checksum.             2 +  2 = 4 */
-	uint32_t ulReserved;     /**< Reserved.             4 +  4 = 8 */
-	IPv6_Address_t xIPv6Address; /**< The IPv6 address.     8 + 16 = 24 */
-	uint8_t ucOptionType;    /**< The option type.     24 +  1 = 25 */
-	uint8_t ucOptionLength;  /**< The option length.   25 +  1 = 26 */
-	uint8_t ucOptionBytes[ 6 ]; /**< Option bytes.        26 +  6 = 32 */
+    uint8_t ucTypeOfMessage;     /**< The message type.     0 +  1 = 1 */
+    uint8_t ucTypeOfService;     /**< Type of service.      1 +  1 = 2 */
+    uint16_t usChecksum;         /**< Checksum.             2 +  2 = 4 */
+    uint32_t ulReserved;         /**< Reserved.             4 +  4 = 8 */
+    IPv6_Address_t xIPv6Address; /**< The IPv6 address.     8 + 16 = 24 */
+    uint8_t ucOptionType;        /**< The option type.     24 +  1 = 25 */
+    uint8_t ucOptionLength;      /**< The option length.   25 +  1 = 26 */
+    uint8_t ucOptionBytes[ 6 ];  /**< Option bytes.        26 +  6 = 32 */
 }
 #include "pack_struct_end.h"
 typedef struct xICMPHeader_IPv6 ICMPHeader_IPv6_t;
@@ -161,45 +172,45 @@ typedef struct xICMPHeader_IPv6 ICMPHeader_IPv6_t;
 #include "pack_struct_start.h"
 struct xICMPEcho_IPv6
 {
-	uint8_t ucTypeOfMessage; /**< The message type.     0 +  1 = 1 */
-	uint8_t ucTypeOfService; /**< Type of service.      1 +  1 = 2 */
-	uint16_t usChecksum;   /**< Checksum.             2 +  2 = 4 */
-	uint16_t usIdentifier; /**< Identifier.           4 +  2 = 6 */
-	uint16_t usSequenceNumber; /**< Sequence number.      6 +  2 = 8 */
+    uint8_t ucTypeOfMessage;   /**< The message type.     0 +  1 = 1 */
+    uint8_t ucTypeOfService;   /**< Type of service.      1 +  1 = 2 */
+    uint16_t usChecksum;       /**< Checksum.             2 +  2 = 4 */
+    uint16_t usIdentifier;     /**< Identifier.           4 +  2 = 6 */
+    uint16_t usSequenceNumber; /**< Sequence number.      6 +  2 = 8 */
 }
 #include "pack_struct_end.h"
 typedef struct xICMPEcho_IPv6 ICMPEcho_IPv6_t;
 
 #if ipconfigUSE_RA != 0
     #include "pack_struct_start.h"
-struct xICMPRouterAdvertisement_IPv6
-{
-	uint8_t ucTypeOfMessage;       /*  0 +  1 =  1 */
-	uint8_t ucTypeOfService;       /*  1 +  1 =  2 */
-	uint16_t usChecksum;           /*  2 +  2 =  4 */
-	uint8_t ucHopLimit;            /*  4 +  1 =  5 */
-	uint8_t ucFlags;               /*  5 +  1 =  6 */
-	uint16_t usLifetime;           /*  6 +  2 =  8 */
-	uint16_t usReachableTime[ 2 ]; /*  8 +  4 = 12 */
-	uint16_t usRetransTime[ 2 ];   /* 12 +  4 = 16 */
-}
+    struct xICMPRouterAdvertisement_IPv6
+    {
+        uint8_t ucTypeOfMessage;       /*  0 +  1 =  1 */
+        uint8_t ucTypeOfService;       /*  1 +  1 =  2 */
+        uint16_t usChecksum;           /*  2 +  2 =  4 */
+        uint8_t ucHopLimit;            /*  4 +  1 =  5 */
+        uint8_t ucFlags;               /*  5 +  1 =  6 */
+        uint16_t usLifetime;           /*  6 +  2 =  8 */
+        uint16_t usReachableTime[ 2 ]; /*  8 +  4 = 12 */
+        uint16_t usRetransTime[ 2 ];   /* 12 +  4 = 16 */
+    }
     #include "pack_struct_end.h"
-typedef struct xICMPRouterAdvertisement_IPv6 ICMPRouterAdvertisement_IPv6_t;
+    typedef struct xICMPRouterAdvertisement_IPv6 ICMPRouterAdvertisement_IPv6_t;
 
     #include "pack_struct_start.h"
-struct xICMPPrefixOption_IPv6
-{
-	uint8_t ucType;               /*  0 +  1 =  1 */
-	uint8_t ucLength;             /*  1 +  1 =  2 */
-	uint8_t ucPrefixLength;       /*  2 +  1 =  3 */
-	uint8_t ucFlags;              /*  3 +  1 =  4 */
-	uint32_t ulValidLifeTime;     /*  4 +  4 =  8 */
-	uint32_t ulPreferredLifeTime; /*  8 +  4 = 12 */
-	uint32_t ulReserved;          /* 12 +  4 = 16 */
-	uint8_t ucPrefix[ 16 ];       /* 16 + 16 = 32 */
-}
+    struct xICMPPrefixOption_IPv6
+    {
+        uint8_t ucType;               /*  0 +  1 =  1 */
+        uint8_t ucLength;             /*  1 +  1 =  2 */
+        uint8_t ucPrefixLength;       /*  2 +  1 =  3 */
+        uint8_t ucFlags;              /*  3 +  1 =  4 */
+        uint32_t ulValidLifeTime;     /*  4 +  4 =  8 */
+        uint32_t ulPreferredLifeTime; /*  8 +  4 = 12 */
+        uint32_t ulReserved;          /* 12 +  4 = 16 */
+        uint8_t ucPrefix[ 16 ];       /* 16 + 16 = 32 */
+    }
     #include "pack_struct_end.h"
-typedef struct xICMPPrefixOption_IPv6 ICMPPrefixOption_IPv6_t;
+    typedef struct xICMPPrefixOption_IPv6 ICMPPrefixOption_IPv6_t;
 #endif /* ipconfigUSE_RA != 0 */
 
 /*-----------------------------------------------------------*/
@@ -209,8 +220,8 @@ typedef struct xICMPPrefixOption_IPv6 ICMPPrefixOption_IPv6_t;
 #include "pack_struct_start.h"
 struct xIP_PACKET_IPv6
 {
-	EthernetHeader_t xEthernetHeader;
-	IPHeader_IPv6_t xIPHeader;
+    EthernetHeader_t xEthernetHeader;
+    IPHeader_IPv6_t xIPHeader;
 }
 #include "pack_struct_end.h"
 typedef struct xIP_PACKET_IPv6 IPPacket_IPv6_t;
@@ -218,9 +229,9 @@ typedef struct xIP_PACKET_IPv6 IPPacket_IPv6_t;
 #include "pack_struct_start.h"
 struct xICMP_PACKET_IPv6
 {
-	EthernetHeader_t xEthernetHeader;
-	IPHeader_IPv6_t xIPHeader;
-	ICMPHeader_IPv6_t xICMPHeaderIPv6;
+    EthernetHeader_t xEthernetHeader;
+    IPHeader_IPv6_t xIPHeader;
+    ICMPHeader_IPv6_t xICMPHeaderIPv6;
 }
 #include "pack_struct_end.h"
 typedef struct xICMP_PACKET_IPv6 ICMPPacket_IPv6_t;
@@ -228,19 +239,19 @@ typedef struct xICMP_PACKET_IPv6 ICMPPacket_IPv6_t;
 #include "pack_struct_start.h"
 struct xUDP_PACKET_IPv6
 {
-	EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
-	IPHeader_IPv6_t xIPHeader;    /* 14 + 40 = 54 */
-	UDPHeader_t xUDPHeader;       /* 54 +  8 = 62 */
+    EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
+    IPHeader_IPv6_t xIPHeader;        /* 14 + 40 = 54 */
+    UDPHeader_t xUDPHeader;           /* 54 +  8 = 62 */
 }
 #include "pack_struct_end.h"
 typedef struct xUDP_PACKET_IPv6 UDPPacket_IPv6_t;
 
-  #include "pack_struct_start.h"
+#include "pack_struct_start.h"
 struct xTCP_PACKET_IPv6
 {
-	EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
-	IPHeader_IPv6_t xIPHeader;    /* 14 + 40 = 54 */
-	TCPHeader_t xTCPHeader;       /* 54 + 32 = 86 */
+    EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
+    IPHeader_IPv6_t xIPHeader;        /* 14 + 40 = 54 */
+    TCPHeader_t xTCPHeader;           /* 54 + 32 = 86 */
 }
 #include "pack_struct_end.h"
 typedef struct xTCP_PACKET_IPv6 TCPPacket_IPv6_t;
@@ -250,21 +261,21 @@ typedef struct xTCP_PACKET_IPv6 TCPPacket_IPv6_t;
 struct xPacketSummary
 {
     #if ( ipconfigUSE_IPv6 != 0 )
-	BaseType_t xIsIPv6;                      /**< pdTRUE for IPv6 packets. */
-	const IPHeader_IPv6_t * pxIPPacket_IPv6; /**< A pointer to the IPv6 header. */
+        BaseType_t xIsIPv6;                      /**< pdTRUE for IPv6 packets. */
+        const IPHeader_IPv6_t * pxIPPacket_IPv6; /**< A pointer to the IPv6 header. */
     #endif
     #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-	const char * pcType;               /**< Just for logging purposes: the name of the protocol. */
+        const char * pcType;               /**< Just for logging purposes: the name of the protocol. */
     #endif
-	size_t uxIPHeaderLength;           /**< Either 40 or 20, depending on the IP-type */
-	size_t uxProtocolHeaderLength;     /**< Either 8, 20, or more or 20, depending on the protocol-type */
-	uint16_t usChecksum;               /**< Checksum accumulator. */
-	uint8_t ucProtocol;                /**< ipPROTOCOL_TCP, ipPROTOCOL_UDP, ipPROTOCOL_ICMP */
-	const IPPacket_t * pxIPPacket;     /**< A pointer to the IPv4 header. */
-	ProtocolHeaders_t * pxProtocolHeaders; /**< Points to first byte after IP-header */
-	uint16_t usPayloadLength;          /**< Property of IP-header (for IPv4: length of IP-header included) */
-	uint16_t usProtocolBytes;          /**< The total length of the protocol data. */
-	uint16_t * pusChecksum;            /**< A pointer to the location where the protocol checksum is stored. */
+    size_t uxIPHeaderLength;               /**< Either 40 or 20, depending on the IP-type */
+    size_t uxProtocolHeaderLength;         /**< Either 8, 20, or more or 20, depending on the protocol-type */
+    uint16_t usChecksum;                   /**< Checksum accumulator. */
+    uint8_t ucProtocol;                    /**< ipPROTOCOL_TCP, ipPROTOCOL_UDP, ipPROTOCOL_ICMP */
+    const IPPacket_t * pxIPPacket;         /**< A pointer to the IPv4 header. */
+    ProtocolHeaders_t * pxProtocolHeaders; /**< Points to first byte after IP-header */
+    uint16_t usPayloadLength;              /**< Property of IP-header (for IPv4: length of IP-header included) */
+    uint16_t usProtocolBytes;              /**< The total length of the protocol data. */
+    uint16_t * pusChecksum;                /**< A pointer to the location where the protocol checksum is stored. */
 };
 
 /* prvProcessICMPMessage_IPv6() is declared in FreeRTOS_routing.c
@@ -284,18 +295,7 @@ FreeRTOS_Socket_t * pxTCPSocketLookupIPv6( UBaseType_t uxLocalPort,
  * value into an array of bytes. They will be stored big-endian.
  * The helper functions do the actual work.
  */
-/*extern void vSetField16helper( uint8_t * pucBase,
-                               size_t uxOffset,
-                               uint16_t usValue );
- #define vSetField16( pucBase, xType, xField, usValue ) \
-    vSetField16helper( pucBase, offsetof( xType, xField ), usValue )
 
-   extern void vSetField32helper( uint8_t * pucBase,
-                               size_t uxOffset,
-                               uint32_t ulValue );
- #define vSetField32( pucBase, xType, xField, ulValue ) \
-    vSetField32helper( pucBase, offsetof( xType, xField ), ulValue )
- */
 /* Get the size of the IP-header.
  * 'usFrameType' must be filled in if IPv6is to be recognised. */
 size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
@@ -303,15 +303,13 @@ size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
 
 /* Get the size of the IP-header.
  * The socket is checked for its type: IPv4 or IPv6. */
-//size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket );
+/*size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket ); */
 /*-----------------------------------------------------------*/
 
 #if ( ( ipconfigHAS_DEBUG_PRINTF != 0 ) || ( ipconfigHAS_PRINTF != 0 ) )
 /* prepare a string which describes a socket, just for logging. */
-const char * prvSocketProps( FreeRTOS_Socket_t * pxSocket );
+    const char * prvSocketProps( FreeRTOS_Socket_t * pxSocket );
 #endif /* ipconfigHAS_DEBUG_PRINTF || ipconfigHAS_PRINTF */
-
-#endif /* ipconfigUSE_IPv6 */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_TCP_IP.h
+++ b/source/include/FreeRTOS_TCP_IP.h
@@ -163,7 +163,6 @@ typedef enum eTCP_STATE
 
 /* Two macro's that were introduced to work with both IPv4 and IPv6. */
 #define xIPHeaderSize( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )          /**< Size of IP Header. */
-#define uxIPHeaderSizeSocket( pxSocket )    ( ipSIZE_OF_IPv4_HEADER )          /**< Size of IP Header socket. */
 
 
 /* *INDENT-OFF* */

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -55,6 +55,7 @@ set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 set( TCP_INCLUDES "${MODULE_ROOT_DIR}/source/include/FreeRTOS_IP.h"
 		  "${MODULE_ROOT_DIR}/source/include/FreeRTOS_IPv4.h"
 		  "${MODULE_ROOT_DIR}/source/include/FreeRTOS_IPv6.h"
+		  "${MODULE_ROOT_DIR}/source/include/FreeRTOS_IP_Common.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_ARP.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_ARP.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_ICMP.h"

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -1121,7 +1121,7 @@ void test_FreeRTOS_SendPingRequest_HappyPath( void )
     TEST_ASSERT_EQUAL( 1, pxICMPHeader->usSequenceNumber );
     TEST_ASSERT_EQUAL( ipIPv4_FRAME_TYPE, pxEthernetHeader->usFrameType );
     TEST_ASSERT_EQUAL( FREERTOS_SO_UDPCKSUM_OUT, pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] );
-    TEST_ASSERT_EQUAL( ulIPAddress, pxNetworkBuffer->ulIPAddress );
+    TEST_ASSERT_EQUAL( ulIPAddress, pxNetworkBuffer->xIPAddress.xIP_IPv4 );
     TEST_ASSERT_EQUAL( ipPACKET_CONTAINS_ICMP_DATA, pxNetworkBuffer->usPort );
 }
 
@@ -1167,7 +1167,7 @@ void test_FreeRTOS_SendPingRequest_SendingToIPTaskFails( void )
     TEST_ASSERT_EQUAL( 1, pxICMPHeader->usSequenceNumber );
     TEST_ASSERT_EQUAL( ipIPv4_FRAME_TYPE, pxEthernetHeader->usFrameType );
     TEST_ASSERT_EQUAL( FREERTOS_SO_UDPCKSUM_OUT, pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] );
-    TEST_ASSERT_EQUAL( ulIPAddress, pxNetworkBuffer->ulIPAddress );
+    TEST_ASSERT_EQUAL( ulIPAddress, pxNetworkBuffer->xIPAddress.xIP_IPv4 );
     TEST_ASSERT_EQUAL( ipPACKET_CONTAINS_ICMP_DATA, pxNetworkBuffer->usPort );
 }
 
@@ -2807,7 +2807,7 @@ void test_prvProcessIPPacket_ARPResolutionReqd_UDP( void )
     TEST_ASSERT_EQUAL( eWaitingARPResolution, eResult );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength ) - sizeof( UDPHeader_t ) + sizeof( UDPPacket_t ), pxNetworkBuffer->xDataLength );
     TEST_ASSERT_EQUAL( pxNetworkBuffer->usPort, pxUDPPacket->xUDPHeader.usSourcePort );
-    TEST_ASSERT_EQUAL( pxNetworkBuffer->ulIPAddress, pxUDPPacket->xIPHeader.ulSourceIPAddress );
+    TEST_ASSERT_EQUAL( pxNetworkBuffer->xIPAddress.xIP_IPv4, pxUDPPacket->xIPHeader.xIP_IPv4 );
 }
 
 void test_prvProcessIPPacket_ARPResolutionReqd_UDP1( void )
@@ -2861,7 +2861,7 @@ void test_prvProcessIPPacket_ARPResolutionReqd_UDP1( void )
 
     TEST_ASSERT_EQUAL( eWaitingARPResolution, eResult );
     TEST_ASSERT_EQUAL( pxNetworkBuffer->usPort, pxUDPPacket->xUDPHeader.usSourcePort );
-    TEST_ASSERT_EQUAL( pxNetworkBuffer->ulIPAddress, pxUDPPacket->xIPHeader.ulSourceIPAddress );
+    TEST_ASSERT_EQUAL( pxNetworkBuffer->xIPAddress.xIP_IPv4, pxUDPPacket->xIPHeader.ulSourceIPAddress );
 }
 
 void test_prvProcessIPPacket_TCP( void )

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -133,7 +133,7 @@ void test_pxDuplicateNetworkBufferWithDescriptor_LargerBufferReturned( void )
     memset( ucEthBuffer2, 0x00, ipconfigTCP_MSS );
 
     pxNetworkBuffer->xDataLength = 0x123;
-    pxNetworkBuffer->ulIPAddress = 0xABCDEF56;
+    pxNetworkBuffer->xIPAddress.xIP_IPv4 = 0xABCDEF56;
     pxNetworkBuffer->usPort = 0x1234;
     pxNetworkBuffer->usBoundPort = 0xFFAA;
 
@@ -143,7 +143,7 @@ void test_pxDuplicateNetworkBufferWithDescriptor_LargerBufferReturned( void )
 
     TEST_ASSERT_EQUAL( &xNetworkBuffer2, pxReturn );
     TEST_ASSERT_EQUAL( xNetworkBuffer2.xDataLength, uxNewLength );
-    TEST_ASSERT_EQUAL( xNetworkBuffer2.ulIPAddress, pxNetworkBuffer->ulIPAddress );
+    TEST_ASSERT_EQUAL( xNetworkBuffer2.xIPAddress.xIP_IPv4, pxNetworkBuffer->xIP_IPv4.ulIPAddress );
     TEST_ASSERT_EQUAL( xNetworkBuffer2.usPort, pxNetworkBuffer->usPort );
     TEST_ASSERT_EQUAL( xNetworkBuffer2.usBoundPort, pxNetworkBuffer->usBoundPort );
     TEST_ASSERT_EQUAL_MEMORY( pxNetworkBuffer->pucEthernetBuffer, xNetworkBuffer2.pucEthernetBuffer, pxNetworkBuffer->xDataLength );
@@ -166,7 +166,7 @@ void test_pxDuplicateNetworkBufferWithDescriptor_SmallerBufferReturned( void )
     memset( ucEthBuffer2, 0x00, ipconfigTCP_MSS );
 
     pxNetworkBuffer->xDataLength = 0x123;
-    pxNetworkBuffer->ulIPAddress = 0xABCDEF56;
+    pxNetworkBuffer->xIPAddress.xIP_IPv4 = 0xABCDEF56;
     pxNetworkBuffer->usPort = 0x1234;
     pxNetworkBuffer->usBoundPort = 0xFFAA;
 
@@ -176,7 +176,7 @@ void test_pxDuplicateNetworkBufferWithDescriptor_SmallerBufferReturned( void )
 
     TEST_ASSERT_EQUAL( &xNetworkBuffer2, pxReturn );
     TEST_ASSERT_EQUAL( xNetworkBuffer2.xDataLength, uxNewLength );
-    TEST_ASSERT_EQUAL( xNetworkBuffer2.ulIPAddress, pxNetworkBuffer->ulIPAddress );
+    TEST_ASSERT_EQUAL( xNetworkBuffer2.xIPAddress.xIP_IPv4, pxNetworkBuffer->xIPAddress.xIP_IPv4 );
     TEST_ASSERT_EQUAL( xNetworkBuffer2.usPort, pxNetworkBuffer->usPort );
     TEST_ASSERT_EQUAL( xNetworkBuffer2.usBoundPort, pxNetworkBuffer->usBoundPort );
     TEST_ASSERT_EQUAL_MEMORY( pxNetworkBuffer->pucEthernetBuffer, xNetworkBuffer2.pucEthernetBuffer, uxNewLength );

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
@@ -117,7 +117,7 @@ void test_vProcessGeneratedUDPPacket_CacheMiss_PacketSmaller( void )
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
     xLocalNetworkBuffer.xDataLength = ipconfigTCP_MSS;
 
-    xLocalNetworkBuffer.ulIPAddress = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
 
     /* Cleanup the ethernet buffer. */
     memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
@@ -155,7 +155,7 @@ void test_vProcessGeneratedUDPPacket_CacheMiss_PacketNotSmaller( void )
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
     xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
 
-    xLocalNetworkBuffer.ulIPAddress = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
 
     /* Cleanup the ethernet buffer. */
     memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
@@ -191,7 +191,7 @@ void test_vProcessGeneratedUDPPacket_UnknownARPReturn( void )
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
     xLocalNetworkBuffer.xDataLength = ipconfigTCP_MSS;
 
-    xLocalNetworkBuffer.ulIPAddress = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
     xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA;
 
     /* Cleanup the ethernet buffer. */
@@ -223,7 +223,7 @@ void test_vProcessGeneratedUDPPacket_CacheHit_NoICMP( void )
 
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
 
-    xLocalNetworkBuffer.ulIPAddress = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
     /* Not ICMP data. */
     xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA + 1;
     xLocalNetworkBuffer.usBoundPort = 0x1023;
@@ -267,7 +267,7 @@ void test_vProcessGeneratedUDPPacket_CacheHit_ICMPPacket_LLMNR_UDPChkSumOption( 
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
     xLocalNetworkBuffer.pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = ucSocketOptions;
 
-    xLocalNetworkBuffer.ulIPAddress = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
     xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA;
     xLocalNetworkBuffer.usBoundPort = 0x1023;
     xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );


### PR DESCRIPTION

Description
-----------

- Add common Header size function for IPv6 and IPv4
- Fix rule 1.1, 10.3, 20.9 and suppress rule 20.5

Test Steps
-----------
As of now compilation test is being done. 
```
cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL
make -C test/build-combination/build/
```

Related Issue
-----------
As unit tests will be done after merging other changes as well. It might break some test cases as of now which will be fixed in upcoming PRs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
